### PR TITLE
Enable Gitpod workspaces with pre-installed dependencies

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,4 @@ ports:
   onOpen: notify
 tasks:
 - command: start-vnc-session.sh
+- command: tmux

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image: pattacini/visual-tactile-localization:latest
+ports:
+- port: 6080
+  onOpen: notify
+tasks:
+- command: start-vnc-session.sh


### PR DESCRIPTION
This PR drops in the `.gitpod.yml` file pointing to the Docker image that provides the dependencies required to run the experiment.

This is, in turn, the Docker file used to generate the image: https://github.com/pattacini/dockerfiles/blob/master/visual-tactile-localization/Dockerfile.

Here's how to enable a VNC browser-based access:

![noVNC](https://user-images.githubusercontent.com/3738070/56656716-82f91400-6696-11e9-91f1-5b9c30d53da0.gif)

This is a valid first step in the direction outlined here: https://spectrum.chat/icub/general/get-yarp-enabled-workspaces-on-the-cloud-with-a-single-click~53ba1286-4d46-4402-94f5-4aa321f03fb5?m=MTU1NTYwODYzNjA3Ng==
