### PR TITLE
Avoid exposing YARP related ports

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,8 @@ image: pattacini/visual-tactile-localization:latest
 ports:
 - port: 6080
   onOpen: notify
+- port: 10000-20000
+  onOpen: ignore
 tasks:
 - command: start-vnc-session.sh
 - command: tmux


### PR DESCRIPTION
Thanks to https://github.com/gitpod-io/gitpod/issues/245 we can now prevent lots of unnecessary notifications from flooding the screen!